### PR TITLE
Be able to parse timestamp where minute has only one digit.

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -58,7 +58,7 @@ DAY (?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:u
 # Years?
 YEAR (?>\d\d){1,2}
 HOUR (?:2[0123]|[01]?[0-9])
-MINUTE (?:[0-5][0-9])
+MINUTE (?:[0-5]?[0-9])
 # '60' is a leap second in most time standards and thus is valid.
 SECOND (?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?)
 TIME (?!<[0-9])%{HOUR}:%{MINUTE}(?::%{SECOND})(?![0-9])


### PR DESCRIPTION
I have a case where a application produces log entries where the timestamp has only one digit. Those entries can't be parsed.

```
2016-4-1 7:9:23 ...   <-- grokparsefailure
2016-4-1 7:13:42 ... 
```

This adjustment in the grok-patterns will allow to parse timestamps with one and two digit minute fields.
